### PR TITLE
Upgrade to newer Rust (a5342d5 2014-02-23)

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -9,7 +9,7 @@ RUST_SRC=$(shell find $(VPATH)/. -type f -name '*.rs')
 all:    libxlib.dummy
 
 libxlib.dummy: lib.rs $(RUST_SRC)
-	$(RUSTC) $(RUSTFLAGS) $< --lib --out-dir .
+	$(RUSTC) $(RUSTFLAGS) $< --crate-type=lib --out-dir .
 	touch $@
 
 xlib-test: lib.rs $(RUST_SRC)

--- a/lib.rs
+++ b/lib.rs
@@ -12,6 +12,6 @@
 
 #[feature(globs)];
 
-extern mod std;
+extern crate std;
 
 pub mod xlib;

--- a/xlib.rs
+++ b/xlib.rs
@@ -8,6 +8,7 @@
 // except according to those terms.
 
 #[allow(non_uppercase_statics)];
+#[allow(non_camel_case_types)];
 
 use std::libc::*;
 


### PR DESCRIPTION
- `s/extern mod/extern crate/`;
- `--crate-type` option for `rustc`;
- allow non Camel case types.
