### PR TITLE
Re-export module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,4 +16,5 @@
 
 extern crate libc;
 
-pub mod xlib;
+pub use xlib::*;
+mod xlib;


### PR DESCRIPTION
I wasn't able to import structs and functions as expected, so I reexported the module which lets me use the library as expected.
