### PR TITLE
Fix alignment of some unions

### DIFF
--- a/src/xlib.rs
+++ b/src/xlib.rs
@@ -1088,15 +1088,13 @@ pub type XIOErrorHandler = *mut u8;
 
 pub type XConnectionWatchProc = *mut u8;
 
-/* FIXME: these are changed from c_void to force alignment */
+pub type union_unnamed3 = usize /* FIXME: union type */;
 
-pub type union_unnamed3 = *const c_void /* FIXME: union type */;
+pub type union_unnamed5 = usize /* FIXME: union type */;
 
-pub type union_unnamed5 = *const c_void /* FIXME: union type */;
+pub type union_unnamed2 = usize /* FIXME: union type */;
 
-pub type union_unnamed2 = c_long /* FIXME: union type */;
-
-pub type union_unnamed4 = *const c_void /* FIXME: union type */;
+pub type union_unnamed4 = usize /* FIXME: union type */;
 
 #[repr(C)]
 pub struct struct_unnamed1 {


### PR DESCRIPTION
Some of the unions in the FFI, represented as `type union_unnamed = c_void`, have bad alignment because C uses the alignment of the largest member. This is pretty much a hack, but it makes it work in a few more cases.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/servo/rust-xlib/31)

<!-- Reviewable:end -->
